### PR TITLE
Navbar bolding consistency, use asset tags, import fonts in one place

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -22,7 +22,6 @@ under the License.
     <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title><%= current_page.data.title || "API Documentation" %></title>
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:100,400,300,700' rel='stylesheet' type='text/css'>
 
     <%= stylesheet_link_tag :screen, media: :screen %>
     <%= stylesheet_link_tag :print, media: :print %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -65,13 +65,12 @@ under the License.
     <a href="#" id="nav-button" class="">
       <span>
         NAV
-        <img src="images/navbar.png" data-pin-nopin="true">
+        <%= image_tag('navbar.png')%>
       </span>
     </a>
     <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
       <div class="navbar-header">
-        <a class="navbar-brand initial" href="/">
-          <img alt="Logo constructor io" height="27" src="/docs/images/logo-constructor-io.png" width="168">
+        <%= link_to image_tag('logo-constructor-io.png', height: '27', width: '168'), "/", class: 'navbar-brand initial' %>
         </a>
       </div>
       <div class="navbar-collapse collapse">
@@ -87,7 +86,6 @@ under the License.
         </ul>
       </div>
   </nav>
-    </a>
     <div class="tocify-wrapper">
       <% if language_tabs %>
         <div class="lang-selector">

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -20,6 +20,12 @@ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 License for the specific language governing permissions and limitations
 under the License.
 */
+////////////////////////////////////////////////////////////////////////////////
+// IMPORTS
+////////////////////////////////////////////////////////////////////////////////
+
+@import url(https://fonts.googleapis.com/css?family=Poppins:500);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:100,300,400,700);
 
 ////////////////////////////////////////////////////////////////////////////////
 // GENERAL STUFF
@@ -31,8 +37,6 @@ html, body {
   color: $main-text;
   padding: 0;
   margin: 0;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
   @extend %default-font;
   background-color: $main-bg;
   height: 100%;
@@ -270,7 +274,6 @@ body {
 ////////////////////////////////////////////////////////////////////////////////
 
 
-@import url(https://fonts.googleapis.com/css?family=Poppins:400,500,600,700);
 $highlight-color: #28b828;
 $hover-color: #248a24;
 $dark-text-color: #989ea2;


### PR DESCRIPTION
The default font smoothing in slate caused our navbar fonts to render as lighter weight in docs than in the rest of the public site. This fixes that issue and cleans up the code a little, including an errant </a> added in the last PR from @JustH.